### PR TITLE
Add on_use_handlers dict field for backward compatibility with cogames

### DIFF
--- a/python/src/mettagrid/config/mettagrid_config.py
+++ b/python/src/mettagrid/config/mettagrid_config.py
@@ -45,6 +45,7 @@ from mettagrid.config.handler_config import (
     AnyHandler,
     AOEConfig,
     Handler,
+    firstMatch,
 )
 from mettagrid.config.id_map import IdMap
 from mettagrid.config.obs_config import (  # noqa: F401 - re-exported
@@ -149,6 +150,10 @@ class GridObjectConfig(Config):
         default=None,
         description="Handler triggered when agent uses/activates this object.",
     )
+    on_use_handlers: dict[str, Handler] = Field(
+        default_factory=dict,
+        description="Dict of named handlers (legacy convenience). Merged into on_use_handler as a FirstMatch composite.",
+    )
     on_tag_remove: dict[str, Handler] = Field(
         default_factory=dict,
         description="Handlers triggered when a matching tag is removed from this object (tag_prefix -> handler)",
@@ -158,6 +163,9 @@ class GridObjectConfig(Config):
     def _defaults_from_name(self) -> "GridObjectConfig":
         if not self.map_name:
             self.map_name = self.name
+        if self.on_use_handlers:
+            merged = firstMatch([self.on_use_handler, *self.on_use_handlers.values()])
+            self.on_use_handler = merged
         return self
 
 


### PR DESCRIPTION
## Summary

- Adds `on_use_handlers: dict[str, Handler]` field to `GridObjectConfig` for backward compatibility with cogames
- The dict is automatically merged into the singular `on_use_handler` field via `firstMatch()` in the existing model validator
- Fixes cogames import crash: `pydantic_core._pydantic_core.ValidationError: Extra inputs are not permitted` for `on_use_handlers`

## Context

The standalone mettagrid repo replaced `on_use_handlers` (dict) with `on_use_handler` (singular `AnyHandler | None`) using composite `FirstMatch`/`AllOf` handler types. However, cogames extensively uses the dict form (`on_use_handlers={...}`) across extractors, hubs, junctions, cognitive substrate evals, and overcogged game configs.

This adds the dict field back as a convenience that bridges to the new singular API — the model validator merges the dict entries into a `FirstMatch` composite, preserving the same runtime behavior.

## Test plan

- [x] Verified `GridObjectConfig(on_use_handlers={"solve": Handler()})` correctly merges into `on_use_handler`
- [x] Verified single-entry dict collapses to plain `Handler` (via `firstMatch` flattening)
- [x] Verified empty dict leaves `on_use_handler` as `None`
- [x] Verified both `on_use_handler` and `on_use_handlers` merge correctly
- [x] Verified `AgentConfig` (inherits from `GridObjectConfig`) also works
- [x] Verified exact cogames exploration.py pattern works without error


Made with [Cursor](https://cursor.com)